### PR TITLE
chore: automate release better

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,8 @@ jobs:
                     - ref: main
                       version: main
                       typst: 0.14.2
-                    - ref: main # not tagged yet
+                    # next-version
+                    - ref: 65674b1dee0a274173f4c5fb45cc27d802222d8f
                       version: v0.2.1
                       typst: 0.13
                     - ref: b6b8f921921877f33899721b13d474e0eab6fced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Types of changes:
     - Security in case of vulnerabilities.
 -->
 
-## [Unreleased]
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
 
 - Updated to ICU4X 2.2
 
@@ -94,7 +96,7 @@ This release is a major change since the last version as it updates the ICU4X de
 - `fmt-timezone` (🚧 experimental)
 - `fmt-zoned-datetime` (🚧 experimental)
 
-[unreleased]: https://github.com/Nerixyz/icu-typ/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/Nerixyz/icu-typ/compare/v0.2.1...HEAD
 [0.2.1]: https://github.com/Nerixyz/icu-typ/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Nerixyz/icu-typ/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/Nerixyz/icu-typ/compare/v0.1.1...v0.1.2

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,6 +4,8 @@ This library is a wrapper around [ICU4X](https://github.com/unicode-org/icu4x)' 
 
 If you're looking for documentation of an older version, append that version to the URL:
 
+<!-- next-version -->
+
 - **v0.2.1**: [nerixyz.github.io/icu-typ/v0.2.1](https://nerixyz.github.io/icu-typ/v0.2.1)
 - **v0.2.0**: [nerixyz.github.io/icu-typ/v0.2.0](https://nerixyz.github.io/icu-typ/v0.2.0)
 - **v0.1.2**: [nerixyz.github.io/icu-typ/v0.1.2](https://nerixyz.github.io/icu-typ/v0.1.2)

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,19 @@
+pre-release-commit-message = "feat: release {{version}}"
+tag = false
+push = false
+publish = false
+consolidate-commits = false
+pre-release-replacements = [
+    { file = "CHANGELOG.md", search = "Unreleased", replace = "v{{version}}", prerelease = false },
+    { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}", prerelease = false },
+    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...v{{version}}", exactly = 1 },
+    { file = "CHANGELOG.md", search = "\\[unreleased\\]:", replace = "[unreleased]: https://github.com/Nerixyz/icu-typ/compare/v{{version}}...HEAD\n[{{version}}]:", exactly = 1 },
+    { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate\n\n[Commits](https://github.com/nerixyz/icu-typ/compare/v{{version}}...HEAD)", prerelease = false },
+    { file = "README.md", search = "@preview/icu-datetime:[a-z0-9\\.-]+", replace = "@preview/icu-datetime:{{version}}", prerelease = false },
+    { file = "docs/docs/index.md", search = "@preview/icu-datetime:[a-z0-9\\.-]+", replace = "@preview/icu-datetime:{{version}}", prerelease = false },
+    { file = "docs/docs/fmt.md", search = "@preview/icu-datetime:[a-z0-9\\.-]+", replace = "@preview/icu-datetime:{{version}}", prerelease = false },
+    { file = "docs/extensions/typst_preview.py", search = "@local/icu-datetime:[a-z0-9\\.-]+", replace = "@local/icu-datetime:{{version}}", prerelease = false },
+    { file = "docs/docs/index.md", search = "<!-- next-version -->\r?\n", replace = "<!--next-version -->\n\n- **v{{version}}**: [nerixyz.github.io/icu-typ/v{{version}}](https://nerixyz.github.io/icu-typ/v{{version}})", prerelease = false },
+    { file = ".github/workflows/build-docs.yml", search = "\n( +)typst: ([a-z0-9\\.-]+)\r?\n( +)# next-version", replace = "\n${1}typst: $2\n$3# next-version\n$3- ref: main # not tagged yet\n$3  version: v{{version}}\n$3  typst: $2", prerelease = false },
+    { file = "typst/typst.toml", search = "version = \"[a-z0-9\\.-]+\"", replace = "version = \"{{version}}\"", prerelease = false },
+]


### PR DESCRIPTION
Use `cargo release` to do the changes, because as you can tell by the diff, I forgot to update some locations in the past.